### PR TITLE
Fix Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,8 @@
     "start": "turbo run start"
   },
   "packageManager": "pnpm@10.12.4",
-  "devDependencies": {
-    "turbo": "^2.5.4"
-  },
   "dependencies": {
+    "turbo": "^2.5.4",
     "next-auth": "^4.24.11",
     "socket.io-client": "^4.8.1"
   }


### PR DESCRIPTION
## Summary
- ensure `turbo` is installed in production by moving it from devDependencies to dependencies

## Testing
- `pnpm start` *(fails: unable to fetch `pnpm` packages)*

------
https://chatgpt.com/codex/tasks/task_e_6871f78496d08333ab9ae714a2c9c1b2